### PR TITLE
adds idle task and workflow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,10 +72,12 @@ target_link_libraries(navigator
 set(PLUGIN_SOURCES
   src/tasks/goto.cpp
   src/tasks/hover.cpp
+  src/tasks/idle.cpp
   src/tasks/survey_area.cpp
   src/tasks/survey_line.cpp
   src/tasks/transit.cpp
   src/workflows/execute_task.cpp
+  src/workflows/idle.cpp
   src/workflows/nav_core.cpp
   src/workflows/task_connector.cpp
   src/workflows/task_manager.cpp

--- a/config/default_stack.yaml
+++ b/config/default_stack.yaml
@@ -10,6 +10,7 @@ plugins:
     executive: project11_navigation/ExecuteTask
     transit: project11_navigation/TaskToTwistStack
     hover: hover/Hover
+    idle: project11_navigation/Idle
     path_follower: path_follower/PathFollower
     survey_line: project11_navigation/TaskToTwistStack
   TaskListToTaskListWorkflow:
@@ -19,6 +20,7 @@ plugins:
   Tasks:
     goto: project11_navigation/GotoTask
     hover: project11_navigation/HoverTask
+    idle: project11_navigation/IdleTask
     survey_area: project11_navigation/SurveyAreaTask
     survey_line: project11_navigation/SurveyLineTask
     transit: project11_navigation/TransitTask

--- a/include/project11_navigation/tasks/idle.h
+++ b/include/project11_navigation/tasks/idle.h
@@ -1,0 +1,18 @@
+#ifndef PROJECT11_NAVIGATION_TASKS_IDLE_H
+#define PROJECT11_NAVIGATION_TASKS_IDLE_H
+
+#include <project11_navigation/task.h>
+
+namespace project11_navigation
+{
+
+class IdleTask: public Task
+{
+public:
+  void updateTransit(const geometry_msgs::PoseStamped& from_pose, geometry_msgs::PoseStamped& out_pose, std::shared_ptr<Context> context) override;
+  boost::shared_ptr<Task> getCurrentNavigationTask() override;
+};
+
+} // namespace project11_navigationf
+
+#endif

--- a/include/project11_navigation/workflows/idle.h
+++ b/include/project11_navigation/workflows/idle.h
@@ -1,0 +1,29 @@
+#ifndef PROJECT11_NAVIGATION_WORKFLOWS_IDLE_H
+#define PROJECT11_NAVIGATION_WORKFLOWS_IDLE_H
+
+#include <project11_navigation/workflow.h>
+#include <project11_navigation/task.h>
+#include <geometry_msgs/TwistStamped.h>
+#include <project11_navigation/interfaces/task_to_twist_workflow.h>
+
+namespace project11_navigation
+{
+
+// Given a Task, forwards it to the apporiate workflow.
+class Idle: public TaskToTwistWorkflow
+{
+public:
+  Idle();
+  ~Idle();
+
+  void configure(std::string name, Context::Ptr context) override;
+  void setGoal(const boost::shared_ptr<Task>& input) override;
+  bool running() override;
+  bool getResult(geometry_msgs::TwistStamped& output) override;
+
+};
+
+}  // namespace project11_navigation
+
+
+#endif

--- a/plugins.xml
+++ b/plugins.xml
@@ -12,6 +12,12 @@
     <description>Project11 Navigation hover task wrapper.</description>
   </class>
 
+   <class base_class_type="project11_navigation::Task"
+      type="project11_navigation::IdleTask"
+      name="project11_navigation/IdleTask">
+    <description>Project11 Navigation idle task wrapper.</description>
+  </class>
+
   <class base_class_type="project11_navigation::Task"
       type="project11_navigation::SurveyAreaTask"
       name="project11_navigation/SurveyAreaTask">
@@ -28,6 +34,12 @@
       type="project11_navigation::TransitTask"
       name="project11_navigation/TransitTask">
     <description>Project11 Navigation wrapper for transit task.</description>
+  </class>
+
+   <class base_class_type="project11_navigation::TaskToTwistWorkflow"
+      type="project11_navigation::Idle"
+      name="project11_navigation/Idle">
+    <description>Project11 Navigation idle task wrapper.</description>
   </class>
 
   <class base_class_type="project11_navigation::TaskToTwistWorkflow"

--- a/src/tasks/idle.cpp
+++ b/src/tasks/idle.cpp
@@ -1,0 +1,22 @@
+#include <project11_navigation/tasks/idle.h>
+#include <project11_navigation/utilities.h>
+#include <project11_navigation/context.h>
+#include <project11_navigation/plugins_loader.h>
+#include <pluginlib/class_list_macros.h>
+
+PLUGINLIB_EXPORT_CLASS(project11_navigation::IdleTask, project11_navigation::Task)
+
+namespace project11_navigation
+{
+
+void IdleTask::updateTransit(const geometry_msgs::PoseStamped& from_pose, geometry_msgs::PoseStamped& out_pose, std::shared_ptr<Context> context)
+{
+  out_pose = from_pose;
+}
+
+boost::shared_ptr<Task> IdleTask::getCurrentNavigationTask()
+{
+  return self();
+}
+
+} // namespace project11_navigation

--- a/src/workflows/idle.cpp
+++ b/src/workflows/idle.cpp
@@ -1,0 +1,47 @@
+#include <project11_navigation/workflows/idle.h>
+#include <project11_navigation/workflows/nav_core.h>
+#include <project11_navigation/workflows/task_to_twist_stack.h>
+#include <project11_navigation/plugins_loader.h>
+#include <pluginlib/class_list_macros.h>
+#include <std_msgs/String.h>
+
+PLUGINLIB_EXPORT_CLASS(project11_navigation::Idle, project11_navigation::TaskToTwistWorkflow)
+
+namespace project11_navigation
+{
+
+Idle::Idle()
+{
+  
+}
+
+Idle::~Idle()
+{
+
+}
+
+void Idle::configure(std::string name, Context::Ptr context)
+{
+ 
+}
+
+void Idle::setGoal(const boost::shared_ptr<Task>& input)
+{
+
+}
+
+bool Idle::running()
+{
+  return true;
+}
+
+bool Idle::getResult(geometry_msgs::TwistStamped& output)
+{
+    output.twist.linear.x = std::nan("");
+    output.twist.linear.y = std::nan("");
+    output.twist.linear.z = std::nan("");
+    return true; 
+}
+
+
+}  // namespace project11_navigation


### PR DESCRIPTION
This adds a full idle task and workflow to the navigator and configures them as part of the default stack. The idle task is very simple, it inherits updateTransit and just returns the in pose as the out pose and for get current navigation task returns itself. The idle workflow also contains not config or goal processing and simple returns nans as its twist output, which I have modified the helm to handle